### PR TITLE
Add Python task runner with Docker and supervisord

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Imagen base de Python
+FROM python:3.11-slim
+
+# Instala supervisord
+RUN apt-get update && apt-get install -y supervisor && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . /app
+
+# Comando por defecto: iniciar supervisord con la configuracion proporcionada
+CMD ["supervisord", "-c", "/app/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# hola
+# Sistema de ejecucion periodica de scripts
+
+Este repositorio contiene un entorno Docker que ejecuta `script_main.py` cada
+cinco minutos. Si la tarea principal falla, automaticamente se ejecuta
+`script_fallback.py` gracias a `supervisor.py`.
+
+## Archivos
+
+- `script_main.py`: tarea principal que falla de forma aleatoria.
+- `script_fallback.py`: tarea de respaldo.
+- `supervisor.py`: ejecuta `script_main.py` y si detecta error lanza el
+  fallback.
+- `supervisord.conf`: configuracion de supervisord que lanza el supervisor cada
+  cinco minutos mediante un bucle `while true`.
+- `Dockerfile`: construye la imagen e inicia supervisord.
+- `docker-compose.yml`: define el servicio Docker con reinicio automatico.
+- `.dockerignore`: excluye archivos innecesarios al crear la imagen.
+
+## Uso rapido
+
+1. Construir y ejecutar con docker compose:
+
+```bash
+docker-compose up --build
+```
+
+2. Detener el servicio con `Ctrl+C` y eliminar contenedores:
+
+```bash
+docker-compose down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  supervisor:
+    build: .
+    container_name: script_supervisor
+    restart: always

--- a/script_fallback.py
+++ b/script_fallback.py
@@ -1,0 +1,13 @@
+import time
+
+
+def main() -> int:
+    """Script de respaldo que se ejecuta si el script principal falla."""
+    print("[fallback] Ejecutando tarea de respaldo...")
+    time.sleep(1)
+    print("[fallback] Tarea de respaldo completada.")
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/script_main.py
+++ b/script_main.py
@@ -1,0 +1,19 @@
+import random
+import time
+import sys
+
+
+def main() -> int:
+    """Simula una tarea que puede fallar aleatoriamente."""
+    print("[main] Ejecutando tarea principal...")
+    time.sleep(1)
+    if random.random() < 0.5:
+        print("[main] Tarea principal completada correctamente.")
+        return 0
+    else:
+        print("[main] Ocurrio un fallo en la tarea principal.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/supervisor.py
+++ b/supervisor.py
@@ -1,0 +1,27 @@
+import subprocess
+from pathlib import Path
+
+
+MAIN_SCRIPT = Path(__file__).with_name("script_main.py")
+FALLBACK_SCRIPT = Path(__file__).with_name("script_fallback.py")
+
+
+def run_script(path: Path) -> int:
+    """Ejecuta un script y retorna su codigo de salida."""
+    print(f"[supervisor] Ejecutando {path}...")
+    result = subprocess.run(["python", str(path)])
+    print(f"[supervisor] Codigo de salida de {path}: {result.returncode}")
+    return result.returncode
+
+
+def main() -> None:
+    code = run_script(MAIN_SCRIPT)
+    if code != 0:
+        print("[supervisor] El script principal fallo. Lanzando fallback...")
+        run_script(FALLBACK_SCRIPT)
+    else:
+        print("[supervisor] Ejecucion completada correctamente.")
+
+
+if __name__ == "__main__":
+    main()

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,8 @@
+[supervisord]
+nodaemon=true
+
+[program:script_supervisor]
+command=/bin/sh -c "while true; do python /app/supervisor.py; sleep 300; done"
+autorestart=false
+stdout_logfile=/dev/stdout
+stderr_logfile=/dev/stderr


### PR DESCRIPTION
## Summary
- add example Python scripts (`script_main.py`, `script_fallback.py`)
- add `supervisor.py` to run main script and fallback on failure
- configure `supervisord` and Docker to run scripts every 5 minutes
- provide `docker-compose.yml`, `.dockerignore`, and usage instructions

## Testing
- `python -m py_compile script_main.py script_fallback.py supervisor.py`
- `docker-compose config` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684512515658832b969bea4195b73a31